### PR TITLE
Edited the post-build events for all 5 projects to check whether the mod folder exists, if not create it.

### DIFF
--- a/Compatibility/v2/compat.v2.csproj
+++ b/Compatibility/v2/compat.v2.csproj
@@ -52,7 +52,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(ProjectName).dll"</PostBuildEvent>
+    <PostBuildEvent>set CS_MOD_FOLDER=%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\
+set PROJECT_MOD_FOLDER=%25CS_MOD_FOLDER%25\$(SolutionName)\
+if not exist "%25PROJECT_MOD_FOLDER%25" mkdir "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(TargetPath)" "%25PROJECT_MOD_FOLDER%25\$(ProjectName).dll"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Compatibility/v3/compat.v3.csproj
+++ b/Compatibility/v3/compat.v3.csproj
@@ -52,7 +52,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(ProjectName).dll"</PostBuildEvent>
+    <PostBuildEvent>set CS_MOD_FOLDER=%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\
+set PROJECT_MOD_FOLDER=%25CS_MOD_FOLDER%25\$(SolutionName)\
+if not exist "%25PROJECT_MOD_FOLDER%25" mkdir "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(TargetPath)" "%25PROJECT_MOD_FOLDER%25\$(ProjectName).dll"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Compatibility/v4/compat.v4.csproj
+++ b/Compatibility/v4/compat.v4.csproj
@@ -52,7 +52,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(ProjectName).dll"</PostBuildEvent>
+    <PostBuildEvent>set CS_MOD_FOLDER=%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\
+set PROJECT_MOD_FOLDER=%25CS_MOD_FOLDER%25\$(SolutionName)\
+if not exist "%25PROJECT_MOD_FOLDER%25" mkdir "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(TargetPath)" "%25PROJECT_MOD_FOLDER%25\$(ProjectName).dll"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Compatibility/v5/compat.v5.csproj
+++ b/Compatibility/v5/compat.v5.csproj
@@ -52,7 +52,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)\$(ProjectName).dll"</PostBuildEvent>
+    <PostBuildEvent>set CS_MOD_FOLDER=%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\
+set PROJECT_MOD_FOLDER=%25CS_MOD_FOLDER%25\$(SolutionName)\
+if not exist "%25PROJECT_MOD_FOLDER%25" mkdir "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(TargetPath)" "%25PROJECT_MOD_FOLDER%25\$(ProjectName).dll"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/RedditSkylines/RedditClient.csproj
+++ b/RedditSkylines/RedditClient.csproj
@@ -62,8 +62,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y "$(TargetPath)" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"
-copy /y "$(SolutionDir)\LICENSE" "%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\$(SolutionName)"</PostBuildEvent>
+    <PostBuildEvent>set CS_MOD_FOLDER=%25LOCALAPPDATA%25\Colossal Order\Cities_Skylines\Addons\Mods\
+set PROJECT_MOD_FOLDER=%25CS_MOD_FOLDER%25\$(SolutionName)\
+if not exist "%25PROJECT_MOD_FOLDER%25" mkdir "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(TargetPath)" "%25PROJECT_MOD_FOLDER%25"
+copy /y "$(SolutionDir)\LICENSE" "%25PROJECT_MOD_FOLDER%25"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Currently the post-build events will not copy the dlls over since the
'RedditClient' folder will not exist on first build in
%LOCALAPPDATA%\Colossal Order\Cities_Skylines\AddOns\Mods
